### PR TITLE
Added alternate autoconf based build system that can support linux to windows cross compile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,0 +1,52 @@
+ACLOCAL_AMFLAGS = -I m4
+
+AM_LDFLAGS = @DEAD_STRIP@
+AM_LDFLAGS += -no-undefined
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libstlsplit.pc
+
+doc_DATA = \
+	README.md \
+	COPYING \
+	AUTHORS \
+	ChangeLog
+
+
+EXTRA_DIST = \
+	$(doc_DATA) \
+	libstlsplit.pc.in
+
+CLEANFILES = libstlsplit.pc
+
+bin_PROGRAMS = stlsplit
+stlsplit_SOURCES = \
+	cli.cpp
+stlsplit_LDADD = \
+	libstlsplit.la
+
+# libstlsplit libtool versioning
+LIBSTLSPLIT_CURRENT=1
+LIBSTLSPLIT_REVISION=0
+LIBSTLSPLIT_AGE=0
+
+pkginclude_HEADERS = stlsplit.h
+lib_LTLIBRARIES = libstlsplit.la
+
+libstlsplit_la_SOURCES = \
+	stlsplit.cpp
+
+libstlsplit_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	-version-info $(LIBSTLSPLIT_CURRENT):$(LIBSTLSPLIT_REVISION):$(LIBSTLSPLIT_AGE)
+
+distclean-local:
+	rm -rf *.cache *~
+
+AUTHORS:
+	git log --format='%aN <%aE>' | sort -u > $@
+
+ChangeLog:
+	./fortag.sh >$@
+
+dist-hook: AUTHORS ChangeLog

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+case `uname` in Darwin*) glibtoolize --copy ;;
+*) libtoolize --force --copy ;; esac
+
+aclocal -I m4
+autoheader
+automake -a -c --foreign
+autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -1,0 +1,91 @@
+dnl Process this file with autoconf to produce a configure script.
+
+AC_PREREQ([2.65])
+
+# ====================
+# Version informations
+# ====================
+m4_define([stlsplit_version_major],[0])
+m4_define([stlsplit_version_minor],[99])
+m4_define([stlsplit_version_micro],[0])
+m4_define([stlsplit_version_suffix],[dev])
+m4_define([stlsplit_version],[stlsplit_version_major.stlsplit_version_minor.stlsplit_version_micro''stlsplit_version_suffix])
+
+# =============
+# Automake init
+# =============
+AC_INIT([stlsplit],[stlsplit_version])
+AC_CONFIG_MACRO_DIR([m4])
+AM_CONFIG_HEADER([config.h])
+AM_INIT_AUTOMAKE([1.11 foreign no-dist-gzip dist-xz subdir-objects])
+AM_SILENT_RULES([yes])
+LT_INIT([disable-static pic-only])
+AC_LANG([C])
+
+# ===========================
+# Find required base packages
+# ===========================
+AC_PROG_CC
+AC_PROG_CXX
+AC_PROG_INSTALL
+AC_PROG_LIBTOOL
+AC_PROG_SED
+AC_PROG_MKDIR_P
+
+# =======================
+# Platform specific setup
+# =======================
+
+AC_CANONICAL_HOST
+case $host_os in
+	darwin* )
+		DEAD_STRIP="-Wl,-dead_strip"
+		;;
+	*)
+		DEAD_STRIP="-Wl,--gc-sections -Wl,--as-needed"
+		;;
+esac
+AC_SUBST(DEAD_STRIP)
+
+# ================
+# Check for cflags
+# ================
+AC_ARG_ENABLE([werror],
+	[AS_HELP_STRING([--enable-werror], [Treat all warnings as errors, useful for development @<:@default=disabled@:>@])],
+	[enable_werror="$enableval"],
+	[enable_werror=no]
+)
+AS_IF([test x"$enable_werror" != "xno"], [
+	CFLAGS="$CFLAGS -Werror"
+	CXXFLAGS="$CXXFLAGS -Werror"
+])
+AS_IF([test x"$GCC" = xyes], [
+	# Be tough with warnings and produce less careless code
+	CFLAGS="$CFLAGS -Wall -Wextra -pedantic -Werror=format-security  -Wp,-D_FORTIFY_SOURCE=2"
+	CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wshadow -pedantic -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2"
+])
+
+# =========
+# Find libs
+# =========
+AC_CHECK_LIB(m, main)
+
+# =====================
+# Prepare all .in files
+# =====================
+AC_CONFIG_FILES([
+Makefile
+libstlsplit.pc
+])
+
+AC_OUTPUT
+
+# ==============================================
+# Display final informations about configuration
+# ==============================================
+AC_MSG_NOTICE([
+==============================================================================
+Build configuration:
+	werror:	  ${enable_werror}
+==============================================================================
+])

--- a/fortag.sh
+++ b/fortag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+lasttag=''
+total=''
+for tag in `git for-each-ref --sort=committerdate --format='%(refname)' refs/tags`; do
+  if [[ x$lasttag != x ]]; then
+    e="${tag#refs/tags/v}: "
+    e="$e`git  --no-pager log -1 --format=%ai $tag`\n\n"
+    e="$e`git --no-pager log --pretty=\"format: * %s\" $lasttag..$tag`\n\n"
+    total="$e$total"
+  fi
+  lasttag=$tag
+done
+echo -en "$total"

--- a/libstlsplit.pc.in
+++ b/libstlsplit.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libstlsplit
+Description: Library for splitting stls
+Version: @VERSION@
+Libs: -L${libdir} -lstlsplit
+Libs.private:
+Cflags: -I${includedir}

--- a/premake4-cross.lua
+++ b/premake4-cross.lua
@@ -1,0 +1,23 @@
+#!lua
+
+solution "stlsplit"
+	location ( "." )
+	targetdir("build")
+	configurations { "Debug", "Release" }
+	platforms {"native", "x64", "x32"}
+
+	configuration "Debug"
+		defines { "DEBUG" }
+		flags { "Symbols", "ExtraWarnings"}
+
+	configuration "Release"
+		defines { "NDEBUG" }
+		flags { "Optimize", "ExtraWarnings"}    
+
+
+	project "lib"
+		language "C++"
+		files { "stlsplit.cpp", "*.h" }
+		targetname ("stlsplit")
+		links { "admesh" }
+		kind "StaticLib"

--- a/premake4.lua
+++ b/premake4.lua
@@ -14,19 +14,26 @@ solution "stlsplit"
 		defines { "NDEBUG" }
 		flags { "Optimize", "ExtraWarnings"}    
 
+        project "static-lib"
+                language "C++"
+                files { "stlsplit.cpp", "*.h" }
+                targetname ("stlsplit")
+                links { "admesh" }
+                kind "StaticLib"
 
 	project "lib"
 		language "C++"
-		kind "SharedLib"
 		files { "stlsplit.cpp", "*.h" }
 		targetname ("stlsplit")
 		links { "admesh" }
 		configuration { "linux" }
+			kind "SharedLib"
 			targetextension (".so.1")
 			linkoptions { "-Wl,-soname,libstlsplit.so.1" }
 			postbuildcommands { "ln -sf libstlsplit.so.1 build/libstlsplit.so" }
 			--cleancommands { "rm build/libstlsplit.so || :" }
 		configuration { "macosx" }
+			kind "SharedLib"
 			targetextension (".1.dylib")
 			postbuildcommands { "ln -sf libstlsplit.1.dylib build/libstlsplit.dylib" }
 			--cleancommands { "rm build/libstlsplit.dylib || :" }

--- a/premake4.lua
+++ b/premake4.lua
@@ -16,24 +16,23 @@ solution "stlsplit"
 
         project "static-lib"
                 language "C++"
+                kind "StaticLib"
                 files { "stlsplit.cpp", "*.h" }
                 targetname ("stlsplit")
                 links { "admesh" }
-                kind "StaticLib"
 
 	project "lib"
 		language "C++"
+		kind "SharedLib"
 		files { "stlsplit.cpp", "*.h" }
 		targetname ("stlsplit")
 		links { "admesh" }
 		configuration { "linux" }
-			kind "SharedLib"
 			targetextension (".so.1")
 			linkoptions { "-Wl,-soname,libstlsplit.so.1" }
 			postbuildcommands { "ln -sf libstlsplit.so.1 build/libstlsplit.so" }
 			--cleancommands { "rm build/libstlsplit.so || :" }
 		configuration { "macosx" }
-			kind "SharedLib"
 			targetextension (".1.dylib")
 			postbuildcommands { "ln -sf libstlsplit.1.dylib build/libstlsplit.dylib" }
 			--cleancommands { "rm build/libstlsplit.dylib || :" }


### PR DESCRIPTION
This PR is required for another PR for ADMeshGUI that adds automatic Windows builds using Linux to Windows cross compile.
This PR was required because I could not get premake4 to create the necessary Makefile for Linux to Windows cross compile,
while the autoconf system has excellent support for a cross compiler setup.
The files were adapted from the admesh build system.

