### PR TITLE
Added a new static library configuration

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -14,6 +14,12 @@ solution "stlsplit"
 		defines { "NDEBUG" }
 		flags { "Optimize", "ExtraWarnings"}    
 
+        project "static-lib"
+                language "C++"
+                kind "StaticLib"
+                files { "stlsplit.cpp", "*.h" }
+                targetname ("stlsplit")
+                links { "admesh" }
 
 	project "lib"
 		language "C++"


### PR DESCRIPTION
This PR allows creating a static library version of stlsplit. This makes it much easier to incorporate it in a cross compiled Windows build of ADMeshGUI.
